### PR TITLE
Add indexes to Whoops::Event model to speed up searching 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       mongo
       mongoid (= 2.0.1)
       rails (~> 3)
-      rake (= 0.8.7)
+      rake (= 0.9.0)
       sass
       will_paginate (~> 3.0.pre2)
 
@@ -52,7 +52,7 @@ GEM
       rack-test (>= 0.5.4)
       selenium-webdriver (~> 0.2.0)
       xpath (~> 0.1.4)
-    childprocess (0.1.9)
+    childprocess (0.2.0)
       ffi (~> 1.0.6)
     columnize (0.3.4)
     diff-lcs (1.1.2)
@@ -81,7 +81,7 @@ GEM
       tzinfo (~> 0.3.22)
       will_paginate (~> 3.0.pre)
     nokogiri (1.5.0)
-    polyglot (0.3.1)
+    polyglot (0.3.2)
     rack (1.2.3)
     rack-mount (0.6.14)
       rack (>= 1.0.0)
@@ -101,9 +101,9 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (~> 0.14.4)
-    rake (0.8.7)
+    rake (0.9.0)
     rbx-require-relative (0.0.5)
-    rdoc (3.8)
+    rdoc (3.9.1)
     rspec (2.6.0)
       rspec-core (~> 2.6.0)
       rspec-expectations (~> 2.6.0)
@@ -123,17 +123,18 @@ GEM
     ruby-debug-base (0.10.4)
       linecache (>= 0.3)
     rubyzip (0.9.4)
-    sass (3.1.4)
+    sass (3.1.7)
     selenium-webdriver (0.2.2)
       childprocess (>= 0.1.9)
       ffi (>= 1.0.7)
       json_pure
       rubyzip
     thor (0.14.6)
-    treetop (1.4.9)
+    treetop (1.4.10)
+      polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.29)
-    will_paginate (3.0.pre2)
+    will_paginate (3.0.pre4)
     xpath (0.1.4)
       nokogiri (~> 1.3)
 
@@ -141,17 +142,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bson_ext
   capybara (>= 0.4.0)
   fabrication
   faker
-  haml
-  mongo
-  mongoid (= 2.0.1)
-  rails (~> 3)
-  rake (= 0.8.7)
   rspec-rails
   ruby-debug
-  sass
   whoops!
-  will_paginate (~> 3.0.pre2)

--- a/app/models/whoops/event.rb
+++ b/app/models/whoops/event.rb
@@ -2,13 +2,15 @@ class Whoops::Event
   include Mongoid::Document
   include FieldNames
   
-  belongs_to :event_group, :class_name => "Whoops::EventGroup"
+  belongs_to :event_group, :class_name => "Whoops::EventGroup", :index=>true
   
   field :details
   field :keywords, :type => String
   field :message, :type => String
   field :event_time, :type => DateTime
-    
+
+  index([[:event_group_id,Mongo::ASCENDING],[:event_time, Mongo::DESCENDING]])
+
   validates_presence_of :message  
   
   before_save :set_keywords, :sanitize_details

--- a/app/models/whoops/event_group.rb
+++ b/app/models/whoops/event_group.rb
@@ -39,7 +39,8 @@ class Whoops::EventGroup
   def send_notifications
     if self.notify_on_next_occurrence && recording_event
       matcher = Whoops::NotificationRule::Matcher.new(self)
-      Whoops::NotificationMailer.event_notification(self, matcher.matches).deliver
+      addresses = matcher.matches
+      Whoops::NotificationMailer.event_notification(self, addresses).deliver unless addresses.blank?
       self.notify_on_next_occurrence = false
     end
   end

--- a/whoops.gemspec
+++ b/whoops.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,lib,config}/**/*"] + ["MIT-LICENSE", "Rakefile", "Gemfile", "README.asciidoc"]
   s.version = "0.1.7"
   
-  s.add_dependency('rake', '0.8.7')
+  s.add_dependency('rake', '0.9.0')
   s.add_dependency('rails', '~>3')
   s.add_dependency('sass')
   s.add_dependency('haml')


### PR DESCRIPTION
Hi Daniel,

Please take a look at my changes and incorporate it into your code base if you think makes sense. 

You may want to mention on your Whoops site (http://www.whoopsapp.com/) that autocreate_indexes: true needs to be added in mongiod.yml for the Whoops server so such indexes can be created when the server restarts. 

As for making events collection capped, since there is no automatic way to convert an existing collection into a capped one, you may want to mention what needs to be done, at least for new adapters of Whoops, so from the beginning the events collection is set capped properly.

Thanks!
Alex
