### PR TITLE
Fix whoops exception calling .html_safe on Fixnum

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    whoops (0.5.0)
+    whoops (0.5.3)
       haml
       kaminari
       mongo

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -5,7 +5,7 @@ module EventsHelper
     when Array           then "<ul class='array'>#{detail.collect{|d| "<li>- #{format_detail(d)}</li>" }.join}</ul>".html_safe
     when Hash            then detail_table(detail)
     else
-      detail.to_s
+      detail.to_s.html_safe
     end
   end
   

--- a/app/views/events/_detail.html.haml
+++ b/app/views/events/_detail.html.haml
@@ -2,4 +2,4 @@
   - detail.to_a.sort{|a,b| a[0] <=> b[0]}.each do |sub_detail|
     %li
       %span.key= sub_detail.first + ":"
-      = format_detail(sub_detail.last).html_safe
+      = format_detail(sub_detail.last)


### PR DESCRIPTION
I saw the following after upgrading our whoops version when trying to view an event:

```
ActionView::Template::Error (undefined method `html_safe' for 60156582:Fixnum):
    2:   - detail.to_a.sort{|a,b| a[0] <=> b[0]}.each do |sub_detail|
    3:     %li
    4:       %span.key= sub_detail.first + ":"
    5:       = format_detail(sub_detail.last).html_safe
```

The other paths through the case statement already call .html_safe on their String return values, simple Strings should too. No?
